### PR TITLE
Give SVG height to help center vertically in tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,8 @@ function sacoronavirus() {
                 'width: 1.5em;' + // make clickable area wider
                 '}' +
                 '.sacoronavirus-close>svg {'+
-                '  width: 1em;' + 
+                '  width: 1em;' +
+                '  height: 0.8em;' + // helps to centre cross in tab
                 '}' +
                 '.sacoronavirus-close>svg>g {' +
                 '  stroke: ' + textColor + ';' +


### PR DESCRIPTION
@craigmj This is a tweak to help center the cross vertically in the tab. The cross got bigger and shifted slightly with your latest PR. (Design-wise, it's meant to be centered not top right.)

I'd prefer to center the cross with flexbox, but I must be missing something and can't get that to work. So this is a magic-number solution for now.
